### PR TITLE
Examples: Use purescript-web-* to implement routing aware code

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,9 @@
     "purescript-node-fs": "^5.0.0",
     "purescript-affjax": "^8.0.0",
     "purescript-debug": "^4.0.0",
-    "purescript-simple-json": "4.4.0"
+    "purescript-simple-json": "4.4.0",
+    "purescript-web-dom": "^2.0.0",
+    "purescript-web-html": "^2.0.1"
   },
   "devDependencies": {}
 }

--- a/src/App.purs
+++ b/src/App.purs
@@ -1,0 +1,39 @@
+module App where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+import Location as Location
+
+data Route = Home | NotFound
+
+print :: String -> Effect Unit
+print msg = log $ "[PS] " <> msg
+
+route :: String -> Route
+route "/" = Home
+route _ = NotFound
+
+redirect :: Route -> Effect Unit
+redirect Home = Location.setPathName "/"
+redirect _ = pure unit
+
+render :: Route -> Effect Unit
+render Home = renderHome
+render NotFound = renderNotFound
+
+renderHome :: Effect Unit
+renderHome = do
+  print "Home Route"
+
+renderNotFound :: Effect Unit
+renderNotFound = do
+  print "Route Not Found"
+
+main :: Effect Unit
+main = do
+  path <- Location.getPathName
+  case path of
+    "/redirect" -> redirect Home
+    other -> render $ route other

--- a/src/Location.purs
+++ b/src/Location.purs
@@ -1,0 +1,14 @@
+module Location (getPathName, setPathName) where
+
+import Prelude
+
+import Effect (Effect)
+import Web.HTML (window)
+import Web.HTML.Location (pathname, setPathname)
+import Web.HTML.Window (location)
+
+getPathName :: Effect String
+getPathName = window >>= location >>= pathname
+
+setPathName :: String -> Effect Unit
+setPathName path = window >>= location >>= setPathname path

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -7,6 +7,7 @@ import Effect.Console (log)
 import Tasks as Tasks
 import Todos as Todos
 import Type.Data.Boolean (kind Boolean)
+import App as App
 
 data Kind = Happy | Neutral
 
@@ -32,6 +33,8 @@ main = do
   print $ show $ Tasks.fromJSON json
   print $ Todos.toJSON items
   print $ show $ Todos.fromJSON json
+
+  App.main
 
   where
     items = [{ title: "Test", completed: false }]


### PR DESCRIPTION
New dependencies:
* https://pursuit.purescript.org/packages/purescript-web-html/
* https://github.com/purescript-web/purescript-web-dom/

Routes to use for testing:
* `/`
* `/redirect`
* `/not-found`
