### PR TITLE
Config: Add `200.html` to implement a catch-all page for client-side routing

### DIFF
--- a/.semaphore/_deploy.yml
+++ b/.semaphore/_deploy.yml
@@ -19,4 +19,5 @@ blocks:
             - cache restore bower_components-$SEMAPHORE_GIT_BRANCH-$(checksum bower.json),bower_components-$SEMAPHORE_GIT_BRANCH
             - npm run pulp build
             - npm run parcel build src/index.html
+            - cp dist/index.html dist/200.html
             - npm run surge dist fun-with-frontend.surge.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+_parcel: src/index.html src/index.ts
+	parcel build src/index.html
+
+_purescript: src/Main.purs
+	pulp test
+	pulp build
+
+build: _purescript _parcel
+
+publish: dist
+	surge dist fun-with-frontend.surge.sh


### PR DESCRIPTION
Reference: https://surge.sh/help/adding-a-200-page-for-client-side-routing

Done via copying `dist/index.html` to `dist/200.html` in after the build step
